### PR TITLE
Create /register and /login Page

### DIFF
--- a/public/x.svg
+++ b/public/x.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-x"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>

--- a/src/app/@auth/(.)login/page.tsx
+++ b/src/app/@auth/(.)login/page.tsx
@@ -1,0 +1,12 @@
+import { Modal } from "@/app/components/Modal";
+import LoginForm from "@/app/components/auth/LoginForm";
+
+export default function LoginModal() {
+  return (
+    <>
+      <Modal>
+        <LoginForm />
+      </Modal>
+    </>
+  );
+}

--- a/src/app/@auth/(.)register/page.tsx
+++ b/src/app/@auth/(.)register/page.tsx
@@ -1,10 +1,12 @@
 import { Modal } from "@/app/components/Modal";
 import RegisterForm from "@/app/components/RegisterForm";
+import { registerFormItems } from "@/app/_data/RegisterFormData";
+
 export default function RegisterModal() {
   return (
     <>
       <Modal>
-        <RegisterForm />
+        <RegisterForm formItems={registerFormItems} />
       </Modal>
     </>
   );

--- a/src/app/@auth/(.)register/page.tsx
+++ b/src/app/@auth/(.)register/page.tsx
@@ -1,0 +1,11 @@
+import { Modal } from "@/app/components/Modal";
+import RegisterForm from "@/app/components/RegisterForm";
+export default function RegisterModal() {
+  return (
+    <>
+      <Modal>
+        <RegisterForm />
+      </Modal>
+    </>
+  );
+}

--- a/src/app/@auth/(.)register/page.tsx
+++ b/src/app/@auth/(.)register/page.tsx
@@ -1,12 +1,11 @@
 import { Modal } from "@/app/components/Modal";
-import RegisterForm from "@/app/components/RegisterForm";
-import { registerFormItems } from "@/app/_data/RegisterFormData";
+import SignupForm from "@/app/components/auth/SignupForm";
 
 export default function RegisterModal() {
   return (
     <>
       <Modal>
-        <RegisterForm formItems={registerFormItems} />
+        <SignupForm />
       </Modal>
     </>
   );

--- a/src/app/@auth/(.)register/page.tsx
+++ b/src/app/@auth/(.)register/page.tsx
@@ -1,11 +1,15 @@
 import { Modal } from "@/app/components/Modal";
 import SignupForm from "@/app/components/auth/SignupForm";
+import Delay from "@/app/components/Delay";
+import RegisterFormSkeleton from "@/app/components/RegisterFormSkeleton";
 
 export default function RegisterModal() {
   return (
     <>
       <Modal>
-        <SignupForm />
+        <Delay placeholder={<RegisterFormSkeleton />} delay={500}>
+          <SignupForm />
+        </Delay>
       </Modal>
     </>
   );

--- a/src/app/@auth/[...catchAll]/page.tsx
+++ b/src/app/@auth/[...catchAll]/page.tsx
@@ -1,0 +1,3 @@
+export default function CatchAll() {
+  return null;
+}

--- a/src/app/@auth/default.tsx
+++ b/src/app/@auth/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null;
+}

--- a/src/app/_data/RegisterFormData.ts
+++ b/src/app/_data/RegisterFormData.ts
@@ -1,32 +1,32 @@
-import { FormItem } from "../_types/types";
+import { FormInput } from "../_types/types";
 import { FormData_t } from "../_types/types";
 
-const emailFormInput: FormItem = {
+const emailFormInput: FormInput = {
   label: "Email Address",
   type: "text",
   id: "email",
   placeholder: "Enter email",
 };
 
-const usernameFormInput: FormItem = {
+const usernameFormInput: FormInput = {
   label: "Username",
   type: "text",
   id: "username",
   placeholder: "Enter username",
 };
 
-const passwordFormInput: FormItem = {
+const passwordFormInput: FormInput = {
   label: "Password",
   type: "text",
   id: "password",
   placeholder: "Enter password",
 };
 
-export const registerFormItems: FormItem[] = [
+export const registerFormInputs: FormInput[] = [
   emailFormInput,
   passwordFormInput,
 ];
-export const loginFormItems: FormItem[] = [
+export const loginFormInputs: FormInput[] = [
   usernameFormInput,
   passwordFormInput,
 ];

--- a/src/app/_data/RegisterFormData.ts
+++ b/src/app/_data/RegisterFormData.ts
@@ -1,0 +1,17 @@
+import { FormItem } from "../_types/types";
+
+const emailInput: FormItem = {
+  label: "Email Address",
+  type: "text",
+  id: "email",
+  placeholder: "Enter email",
+};
+
+const passwordInput: FormItem = {
+  label: "Password",
+  type: "text",
+  id: "password",
+  placeholder: "Enter password",
+};
+
+export const registerFormItems: FormItem[] = [emailInput, passwordInput];

--- a/src/app/_data/RegisterFormData.ts
+++ b/src/app/_data/RegisterFormData.ts
@@ -1,17 +1,42 @@
 import { FormItem } from "../_types/types";
+import { FormData_t } from "../_types/types";
 
-const emailInput: FormItem = {
+const emailFormInput: FormItem = {
   label: "Email Address",
   type: "text",
   id: "email",
   placeholder: "Enter email",
 };
 
-const passwordInput: FormItem = {
+const usernameFormInput: FormItem = {
+  label: "Username",
+  type: "text",
+  id: "username",
+  placeholder: "Enter username",
+};
+
+const passwordFormInput: FormItem = {
   label: "Password",
   type: "text",
   id: "password",
   placeholder: "Enter password",
 };
 
-export const registerFormItems: FormItem[] = [emailInput, passwordInput];
+export const registerFormItems: FormItem[] = [
+  emailFormInput,
+  passwordFormInput,
+];
+export const loginFormItems: FormItem[] = [
+  usernameFormInput,
+  passwordFormInput,
+];
+
+export const registerFormData: FormData_t = {
+  title: "Start Bartering",
+  button: "Create Account",
+};
+
+export const loginFormData: FormData_t = {
+  title: "Login Now",
+  button: "Login",
+};

--- a/src/app/_data/RegisterFormData.ts
+++ b/src/app/_data/RegisterFormData.ts
@@ -37,6 +37,6 @@ export const registerFormData: FormData_t = {
 };
 
 export const loginFormData: FormData_t = {
-  title: "Login Now",
+  title: "Welcome Back",
   button: "Login",
 };

--- a/src/app/_types/types.ts
+++ b/src/app/_types/types.ts
@@ -4,3 +4,8 @@ export type FormItem = {
   id: string;
   placeholder: string;
 };
+
+export type FormData_t = {
+  title: string;
+  button: string;
+};

--- a/src/app/_types/types.ts
+++ b/src/app/_types/types.ts
@@ -1,4 +1,4 @@
-export type FormItem = {
+export type FormInput = {
   label: string;
   type: string;
   id: string;

--- a/src/app/_types/types.ts
+++ b/src/app/_types/types.ts
@@ -1,0 +1,6 @@
+export type FormItem = {
+  label: string;
+  type: string;
+  id: string;
+  placeholder: string;
+};

--- a/src/app/components/CornerButton.tsx
+++ b/src/app/components/CornerButton.tsx
@@ -1,0 +1,33 @@
+import Image from "next/image";
+
+interface CornerButtonProps {
+  icon: string;
+  onClick: () => void;
+  size: number;
+  alt: string;
+  topRight?: boolean;
+  topLeft?: boolean;
+}
+
+const CornerButton = ({
+  icon,
+  onClick,
+  size,
+  alt,
+  topRight = false,
+  topLeft = false,
+}: CornerButtonProps) => {
+  const cornerPosition = topRight ? "top-2 right-2" : "top-2 left-2";
+  return (
+    <>
+      <button
+        onClick={onClick}
+        className={`absolute ${cornerPosition} text-gray-600 hover:text-gray-800`}
+      >
+        <Image src={icon} alt={alt} width={size} height={size} />
+      </button>
+    </>
+  );
+};
+
+export default CornerButton;

--- a/src/app/components/Delay.tsx
+++ b/src/app/components/Delay.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useState } from "react";
+
+interface DelayProps {
+  delay: number;
+  placeholder: React.ReactNode;
+  children: React.ReactNode;
+}
+export default function Delay({ delay, placeholder, children }: DelayProps) {
+  const [isDelayed, setDelayed] = useState<boolean>(true);
+  setTimeout(() => {
+    setDelayed(false);
+  }, delay);
+
+  if (isDelayed) {
+    return <>{placeholder};</>;
+  }
+
+  return <>{children}</>;
+}

--- a/src/app/components/Modal.tsx
+++ b/src/app/components/Modal.tsx
@@ -1,17 +1,6 @@
-"use client";
-
-import { useRouter } from "next/navigation";
-
 export function Modal({ children }: { children: React.ReactNode }) {
-  const router = useRouter();
-  const closeModal = () => {
-    router.back();
-  };
   return (
-    <div
-      // onClick={closeModal}
-      className="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm flex items-center justify-center z-50"
-    >
+    <div className="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm flex items-center justify-center z-50">
       {children}
     </div>
   );

--- a/src/app/components/Modal.tsx
+++ b/src/app/components/Modal.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export function Modal({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const closeModal = () => {
+    router.back();
+  };
+  return (
+    <div
+      // onClick={closeModal}
+      className="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm flex items-center justify-center z-50"
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/app/components/RegisterForm.tsx
+++ b/src/app/components/RegisterForm.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/navigation";
 import { FormInput } from "../_types/types";
 import { FormData_t } from "../_types/types";
 import Image from "next/image";
+import CornerButton from "./CornerButton";
 
 interface RegisterFormProps {
   formData: FormData_t;
@@ -20,12 +21,13 @@ const RegisterForm = ({ formData, FormInputs, footer }: RegisterFormProps) => {
     <>
       <div className=" relative h-[420px] max-w-sm w-full p-1 bg-white rounded-md shadow-lg border-black border-[1px] flex flex-col items-center justify-evenly">
         <div className="border-black-600 w-5/6 h-5/6 flex flex-col  justify-evenly animate-fadeIn">
-          <button
+          <CornerButton
+            icon="/x.svg"
             onClick={closeModal}
-            className="absolute top-2 right-2 text-gray-600 hover:text-gray-800"
-          >
-            <Image src="/x.svg" alt="exit" width={24} height={24} />
-          </button>
+            size={24}
+            alt="Exit button"
+            topRight={true}
+          />
           <h2 className=" font-bold text-3xl animate-fadeIn">
             {formData.title}
           </h2>

--- a/src/app/components/RegisterForm.tsx
+++ b/src/app/components/RegisterForm.tsx
@@ -1,39 +1,32 @@
 "use client";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { FormItem } from "../_types/types";
 
-export default function RegisterForm() {
+export default function RegisterForm({ formItems }: { formItems: FormItem[] }) {
   const router = useRouter();
   const closeModal = () => {
     router.back();
   };
   return (
     <>
-      <div className="  h-[380px] max-w-sm w-full p-2 bg-white rounded-md shadow-lg border-black border-[1px] flex flex-col items-center justify-evenly">
+      <div className="  h-[420px] max-w-sm w-full p-4 bg-white rounded-md shadow-lg border-black border-[1px] flex flex-col items-center justify-evenly">
         <h2 className=" font-bold text-3xl">Start Bartering</h2>
         <div className="flex flex-col">
-          <label htmlFor="email" className="font-semibold">
-            Email Address
-          </label>
-          <input
-            type="text"
-            id="email"
-            name="email"
-            placeholder="Enter E-mail"
-            className="border-black border-[1px] px-2 py-1"
-          />
-        </div>
-        <div className="flex flex-col">
-          <label htmlFor="password" className="font-semibold">
-            Password
-          </label>
-          <input
-            type="text"
-            name="password"
-            id="password"
-            placeholder="Enter Password"
-            className="border-black border-[1px] px-2 py-1"
-          />
+          {formItems.map((item) => (
+            <>
+              <label htmlFor={item.id} className="font-semibold">
+                {item.label}
+              </label>
+              <input
+                type={item.type}
+                id={item.id}
+                name={item.id}
+                placeholder={item.placeholder}
+                className="border-black border-[1px] px-2 py-1 mb-3"
+              />
+            </>
+          ))}
         </div>
         <div>
           <button
@@ -50,12 +43,15 @@ export default function RegisterForm() {
           Close Modal
         </button>
         <div className="text-center text-xs">
+          <p className=" text-sm mb-2">
+            Already have an account?{" "}
+            <Link href="/login" className="font-semibold underline">
+              Log in
+            </Link>
+          </p>
           <p>
             By creating an account, I accept Swapify's{" "}
-            <Link
-              href="/terms-of-service"
-              className="font-semibold text-blue-600"
-            >
+            <Link href="/terms-of-service" className="font-semibold">
               Terms of Service
             </Link>
           </p>

--- a/src/app/components/RegisterForm.tsx
+++ b/src/app/components/RegisterForm.tsx
@@ -1,18 +1,18 @@
 "use client";
 import { useRouter } from "next/navigation";
-import { FormItem } from "../_types/types";
+import { FormInput } from "../_types/types";
 import { FormData_t } from "../_types/types";
 import Image from "next/image";
 
 interface RegisterFormProps {
   formData: FormData_t;
-  formItems: FormItem[];
+  FormInputs: FormInput[];
   footer?: React.ReactNode;
 }
 
 export default function RegisterForm({
   formData,
-  formItems,
+  FormInputs,
   footer,
 }: RegisterFormProps) {
   const router = useRouter();
@@ -33,7 +33,7 @@ export default function RegisterForm({
             {formData.title}
           </h2>
           <div className="flex flex-col w-full animate-fadeIn">
-            {formItems.map((item) => (
+            {FormInputs.map((item) => (
               <>
                 <label htmlFor={item.id} className="font-semibold">
                   {item.label}

--- a/src/app/components/RegisterForm.tsx
+++ b/src/app/components/RegisterForm.tsx
@@ -20,39 +20,43 @@ export default function RegisterForm({
   };
   return (
     <>
-      <div className=" relative h-[420px] max-w-sm w-full p-4 bg-white rounded-md shadow-lg border-black border-[1px] flex flex-col items-center justify-evenly">
-        <button
-          onClick={closeModal}
-          className="absolute top-2 right-2 text-gray-600 hover:text-gray-800"
-        >
-          Exit
-        </button>
-        <h2 className=" font-bold text-3xl animate-fadeIn">{formData.title}</h2>
-        <div className="flex flex-col animate-fadeIn">
-          {formItems.map((item) => (
-            <>
-              <label htmlFor={item.id} className="font-semibold">
-                {item.label}
-              </label>
-              <input
-                type={item.type}
-                id={item.id}
-                name={item.id}
-                placeholder={item.placeholder}
-                className="border-black border-[1px] px-2 py-1 mb-3"
-              />
-            </>
-          ))}
-        </div>
-        <div className="animate-fadeIn">
+      <div className=" relative h-[420px] max-w-sm w-full p-1 bg-white rounded-md shadow-lg border-black border-[1px] flex flex-col items-center justify-evenly">
+        <div className="border-black-600 w-5/6 h-5/6 flex flex-col  justify-evenly animate-fadeIn">
           <button
-            type="submit"
-            className=" bg-main-pink text-white px-4 py-2 rounded-sm"
+            onClick={closeModal}
+            className="absolute top-2 right-2 text-gray-600 hover:text-gray-800"
           >
-            {formData.button}
+            Exit
           </button>
+          <h2 className=" font-bold text-3xl animate-fadeIn">
+            {formData.title}
+          </h2>
+          <div className="flex flex-col w-full animate-fadeIn">
+            {formItems.map((item) => (
+              <>
+                <label htmlFor={item.id} className="font-semibold">
+                  {item.label}
+                </label>
+                <input
+                  type={item.type}
+                  id={item.id}
+                  name={item.id}
+                  placeholder={item.placeholder}
+                  className="border-black border-[1px] px-2 py-1 mb-3 w-full"
+                />
+              </>
+            ))}
+          </div>
+          <div className="animate-fadeIn w-full">
+            <button
+              type="submit"
+              className="bg-main-lightblack text-white px-4 py-2 rounded-sm w-full"
+            >
+              {formData.button}
+            </button>
+          </div>
+          {footer}
         </div>
-        {footer}
       </div>
     </>
   );

--- a/src/app/components/RegisterForm.tsx
+++ b/src/app/components/RegisterForm.tsx
@@ -2,6 +2,7 @@
 import { useRouter } from "next/navigation";
 import { FormItem } from "../_types/types";
 import { FormData_t } from "../_types/types";
+import Image from "next/image";
 
 interface RegisterFormProps {
   formData: FormData_t;
@@ -26,7 +27,7 @@ export default function RegisterForm({
             onClick={closeModal}
             className="absolute top-2 right-2 text-gray-600 hover:text-gray-800"
           >
-            Exit
+            <Image src="/x.svg" alt="exit" width={24} height={24} />
           </button>
           <h2 className=" font-bold text-3xl animate-fadeIn">
             {formData.title}

--- a/src/app/components/RegisterForm.tsx
+++ b/src/app/components/RegisterForm.tsx
@@ -10,15 +10,12 @@ interface RegisterFormProps {
   footer?: React.ReactNode;
 }
 
-export default function RegisterForm({
-  formData,
-  FormInputs,
-  footer,
-}: RegisterFormProps) {
+const RegisterForm = ({ formData, FormInputs, footer }: RegisterFormProps) => {
   const router = useRouter();
   const closeModal = () => {
     router.back();
   };
+
   return (
     <>
       <div className=" relative h-[420px] max-w-sm w-full p-1 bg-white rounded-md shadow-lg border-black border-[1px] flex flex-col items-center justify-evenly">
@@ -61,4 +58,6 @@ export default function RegisterForm({
       </div>
     </>
   );
-}
+};
+
+export default RegisterForm;

--- a/src/app/components/RegisterForm.tsx
+++ b/src/app/components/RegisterForm.tsx
@@ -1,9 +1,19 @@
 "use client";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { FormItem } from "../_types/types";
+import { FormData_t } from "../_types/types";
 
-export default function RegisterForm({ formItems }: { formItems: FormItem[] }) {
+interface RegisterFormProps {
+  formData: FormData_t;
+  formItems: FormItem[];
+  footer?: React.ReactNode;
+}
+
+export default function RegisterForm({
+  formData,
+  formItems,
+  footer,
+}: RegisterFormProps) {
   const router = useRouter();
   const closeModal = () => {
     router.back();
@@ -11,7 +21,7 @@ export default function RegisterForm({ formItems }: { formItems: FormItem[] }) {
   return (
     <>
       <div className="  h-[420px] max-w-sm w-full p-4 bg-white rounded-md shadow-lg border-black border-[1px] flex flex-col items-center justify-evenly">
-        <h2 className=" font-bold text-3xl">Start Bartering</h2>
+        <h2 className=" font-bold text-3xl">{formData.title}</h2>
         <div className="flex flex-col">
           {formItems.map((item) => (
             <>
@@ -33,7 +43,7 @@ export default function RegisterForm({ formItems }: { formItems: FormItem[] }) {
             type="submit"
             className=" bg-main-pink text-white px-4 py-2 rounded-sm"
           >
-            Create Account
+            {formData.button}
           </button>
         </div>
         <button
@@ -42,20 +52,7 @@ export default function RegisterForm({ formItems }: { formItems: FormItem[] }) {
         >
           Close Modal
         </button>
-        <div className="text-center text-xs">
-          <p className=" text-sm mb-2">
-            Already have an account?{" "}
-            <Link href="/login" className="font-semibold underline">
-              Log in
-            </Link>
-          </p>
-          <p>
-            By creating an account, I accept Swapify's{" "}
-            <Link href="/terms-of-service" className="font-semibold">
-              Terms of Service
-            </Link>
-          </p>
-        </div>
+        {footer}
       </div>
     </>
   );

--- a/src/app/components/RegisterForm.tsx
+++ b/src/app/components/RegisterForm.tsx
@@ -1,0 +1,66 @@
+"use client";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+export default function RegisterForm() {
+  const router = useRouter();
+  const closeModal = () => {
+    router.back();
+  };
+  return (
+    <>
+      <div className="  h-[380px] max-w-sm w-full p-2 bg-white rounded-md shadow-lg border-black border-[1px] flex flex-col items-center justify-evenly">
+        <h2 className=" font-bold text-3xl">Start Bartering</h2>
+        <div className="flex flex-col">
+          <label htmlFor="email" className="font-semibold">
+            Email Address
+          </label>
+          <input
+            type="text"
+            id="email"
+            name="email"
+            placeholder="Enter E-mail"
+            className="border-black border-[1px] px-2 py-1"
+          />
+        </div>
+        <div className="flex flex-col">
+          <label htmlFor="password" className="font-semibold">
+            Password
+          </label>
+          <input
+            type="text"
+            name="password"
+            id="password"
+            placeholder="Enter Password"
+            className="border-black border-[1px] px-2 py-1"
+          />
+        </div>
+        <div>
+          <button
+            type="submit"
+            className=" bg-main-pink text-white px-4 py-2 rounded-sm"
+          >
+            Create Account
+          </button>
+        </div>
+        <button
+          onClick={closeModal}
+          className=" bg-main-lightblack text-white px-4 py-2 rounded-sm"
+        >
+          Close Modal
+        </button>
+        <div className="text-center text-xs">
+          <p>
+            By creating an account, I accept Swapify's{" "}
+            <Link
+              href="/terms-of-service"
+              className="font-semibold text-blue-600"
+            >
+              Terms of Service
+            </Link>
+          </p>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/components/RegisterForm.tsx
+++ b/src/app/components/RegisterForm.tsx
@@ -20,9 +20,15 @@ export default function RegisterForm({
   };
   return (
     <>
-      <div className="  h-[420px] max-w-sm w-full p-4 bg-white rounded-md shadow-lg border-black border-[1px] flex flex-col items-center justify-evenly">
-        <h2 className=" font-bold text-3xl">{formData.title}</h2>
-        <div className="flex flex-col">
+      <div className=" relative h-[420px] max-w-sm w-full p-4 bg-white rounded-md shadow-lg border-black border-[1px] flex flex-col items-center justify-evenly">
+        <button
+          onClick={closeModal}
+          className="absolute top-2 right-2 text-gray-600 hover:text-gray-800"
+        >
+          Exit
+        </button>
+        <h2 className=" font-bold text-3xl animate-fadeIn">{formData.title}</h2>
+        <div className="flex flex-col animate-fadeIn">
           {formItems.map((item) => (
             <>
               <label htmlFor={item.id} className="font-semibold">
@@ -38,7 +44,7 @@ export default function RegisterForm({
             </>
           ))}
         </div>
-        <div>
+        <div className="animate-fadeIn">
           <button
             type="submit"
             className=" bg-main-pink text-white px-4 py-2 rounded-sm"
@@ -46,12 +52,6 @@ export default function RegisterForm({
             {formData.button}
           </button>
         </div>
-        <button
-          onClick={closeModal}
-          className=" bg-main-lightblack text-white px-4 py-2 rounded-sm"
-        >
-          Close Modal
-        </button>
         {footer}
       </div>
     </>

--- a/src/app/components/RegisterFormSkeleton.tsx
+++ b/src/app/components/RegisterFormSkeleton.tsx
@@ -1,0 +1,26 @@
+import Image from "next/image";
+export default function RegisterFormSkeleton() {
+  return (
+    <>
+      <div className=" relative h-[420px] max-w-sm w-full p-1 bg-white rounded-md shadow-lg border-black border-[1px] flex flex-col items-center justify-evenly">
+        <div className="border-black-600 w-5/6 h-5/6 flex flex-col  justify-evenly ">
+          <button className="absolute top-2 right-2 text-gray-600 hover:text-gray-800">
+            <Image src="/x.svg" alt="exit" width={24} height={24} />
+          </button>
+          <h2 className="text-3xl w-full h-8 bg-shimmer-pattern bg-200% animate-shimmer "></h2>
+          <div className="flex flex-col w-full ">
+            {Array.from({ length: 2 }, (_, i) => (
+              <>
+                <p className="w-1/2 h-5 mb-2 mt-2 bg-shimmer-pattern bg-200% animate-shimmer"></p>
+                <input className=" px-2 py-1 mb-3 w-full bg-shimmer-pattern bg-200% animate-shimmer" />
+              </>
+            ))}
+          </div>
+          <div className="w-full">
+            <button className="h-9 rounded-sm w-full bg-shimmer-pattern bg-200% animate-shimmer"></button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/components/auth/LoginFooter.tsx
+++ b/src/app/components/auth/LoginFooter.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 export default function LoginFooter() {
   return (
     <>
-      <div className="text-center text-xs">
+      <div className="text-center text-xs animate-fadeIn">
         <p className=" text-sm mb-2">
           Don't have an account?{" "}
           <Link href="/register" className="font-semibold underline">

--- a/src/app/components/auth/LoginFooter.tsx
+++ b/src/app/components/auth/LoginFooter.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+
+export default function LoginFooter() {
+  return (
+    <>
+      <div className="text-center text-xs">
+        <p className=" text-sm mb-2">
+          Don't have an account?{" "}
+          <Link href="/register" className="font-semibold underline">
+            Sign up
+          </Link>
+        </p>
+      </div>
+    </>
+  );
+}

--- a/src/app/components/auth/LoginForm.tsx
+++ b/src/app/components/auth/LoginForm.tsx
@@ -1,0 +1,14 @@
+import RegisterForm from "../RegisterForm";
+import { loginFormData } from "@/app/_data/RegisterFormData";
+import { loginFormItems } from "@/app/_data/RegisterFormData";
+import LoginFooter from "./LoginFooter";
+
+export default function LoginForm() {
+  return (
+    <RegisterForm
+      formData={loginFormData}
+      formItems={loginFormItems}
+      footer={<LoginFooter />}
+    />
+  );
+}

--- a/src/app/components/auth/LoginForm.tsx
+++ b/src/app/components/auth/LoginForm.tsx
@@ -1,13 +1,13 @@
 import RegisterForm from "../RegisterForm";
 import { loginFormData } from "@/app/_data/RegisterFormData";
-import { loginFormItems } from "@/app/_data/RegisterFormData";
+import { loginFormInputs } from "@/app/_data/RegisterFormData";
 import LoginFooter from "./LoginFooter";
 
 export default function LoginForm() {
   return (
     <RegisterForm
       formData={loginFormData}
-      formItems={loginFormItems}
+      FormInputs={loginFormInputs}
       footer={<LoginFooter />}
     />
   );

--- a/src/app/components/auth/RegisterFooter.tsx
+++ b/src/app/components/auth/RegisterFooter.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 export default function RegisterFooter() {
   return (
     <>
-      <div className="text-center text-xs">
+      <div className="text-center text-xs animate-fadeIn">
         <p className=" text-sm mb-2">
           Already have an account?{" "}
           <Link href="/login" className="font-semibold underline">

--- a/src/app/components/auth/RegisterFooter.tsx
+++ b/src/app/components/auth/RegisterFooter.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+
+export default function RegisterFooter() {
+  return (
+    <>
+      <div className="text-center text-xs">
+        <p className=" text-sm mb-2">
+          Already have an account?{" "}
+          <Link href="/login" className="font-semibold underline">
+            Log in
+          </Link>
+        </p>
+        <p>
+          By creating an account, I accept Swapify's{" "}
+          <Link href="/terms-of-service" className="font-semibold">
+            Terms of Service
+          </Link>
+        </p>
+      </div>
+    </>
+  );
+}

--- a/src/app/components/auth/SignupForm.tsx
+++ b/src/app/components/auth/SignupForm.tsx
@@ -1,12 +1,12 @@
 import RegisterForm from "../RegisterForm";
 import { registerFormData } from "@/app/_data/RegisterFormData";
-import { registerFormItems } from "@/app/_data/RegisterFormData";
+import { registerFormInputs } from "@/app/_data/RegisterFormData";
 import RegisterFooter from "./RegisterFooter";
 export default function SignupForm() {
   return (
     <RegisterForm
       formData={registerFormData}
-      formItems={registerFormItems}
+      FormInputs={registerFormInputs}
       footer={<RegisterFooter />}
     />
   );

--- a/src/app/components/auth/SignupForm.tsx
+++ b/src/app/components/auth/SignupForm.tsx
@@ -1,0 +1,13 @@
+import RegisterForm from "../RegisterForm";
+import { registerFormData } from "@/app/_data/RegisterFormData";
+import { registerFormItems } from "@/app/_data/RegisterFormData";
+import RegisterFooter from "./RegisterFooter";
+export default function SignupForm() {
+  return (
+    <RegisterForm
+      formData={registerFormData}
+      formItems={registerFormItems}
+      footer={<RegisterFooter />}
+    />
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,7 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
+/* :root {
   --foreground-rgb: 0, 0, 0;
   --background-start-rgb: 214, 219, 220;
   --background-end-rgb: 255, 255, 255;
@@ -14,7 +14,7 @@
     --background-start-rgb: 0, 0, 0;
     --background-end-rgb: 0, 0, 0;
   }
-}
+} 
 
 body {
   color: rgb(var(--foreground-rgb));
@@ -30,4 +30,4 @@ body {
   .text-balance {
     text-wrap: balance;
   }
-}
+} */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,12 +11,17 @@ export const metadata: Metadata = {
 
 export default function RootLayout({
   children,
+  auth,
 }: Readonly<{
   children: React.ReactNode;
+  auth: React.ReactNode;
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        {auth}
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,10 +1,10 @@
-import SignupForm from "../components/auth/SignupForm";
+import LoginForm from "../components/auth/LoginForm";
 
-export default function Signup() {
+export default function Login() {
   return (
     <>
       <div className="w-screen h-screen flex justify-center items-center">
-        <SignupForm />
+        <LoginForm />
       </div>
     </>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,12 @@
 import Image from "next/image";
+import Link from "next/link";
 
 export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-between p-24">
       <div className="z-10 w-full max-w-5xl items-center justify-between font-mono text-sm lg:flex">
         <p className="fixed left-0 top-0 flex w-full justify-center border-b border-gray-300 bg-gradient-to-b from-zinc-200 pb-6 pt-8 backdrop-blur-2xl dark:border-neutral-800 dark:bg-zinc-800/30 dark:from-inherit lg:static lg:w-auto  lg:rounded-xl lg:border lg:bg-gray-200 lg:p-4 lg:dark:bg-zinc-800/30">
-          Get started by editing&nbsp;
-          <code className="font-mono font-bold">src/app/page.tsx</code>
+          <Link href="/register">Link to Register</Link>
         </p>
         <div className="fixed bottom-0 left-0 flex h-48 w-full items-end justify-center bg-gradient-to-t from-white via-white dark:from-black dark:via-black lg:static lg:size-auto lg:bg-none">
           <a

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+import Link from "next/link";
+import RegisterForm from "../components/RegisterForm";
+
+export default function Register() {
+  return (
+    <>
+      <div className="w-screen h-screen flex justify-center items-center">
+        <RegisterForm />
+      </div>
+    </>
+  );
+}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,12 +1,12 @@
 "use client";
-import Link from "next/link";
 import RegisterForm from "../components/RegisterForm";
+import { registerFormItems } from "../_data/RegisterFormData";
 
 export default function Register() {
   return (
     <>
       <div className="w-screen h-screen flex justify-center items-center">
-        <RegisterForm />
+        <RegisterForm formItems={registerFormItems} />
       </div>
     </>
   );

--- a/src/app/terms-of-service/page.tsx
+++ b/src/app/terms-of-service/page.tsx
@@ -1,0 +1,12 @@
+export default function TermsOfService() {
+  return (
+    <>
+      <div className="w-screen h-screen flex justify-center text-center">
+        <div>
+          <h1 className=" text-2xl font-semibold">Terms of Service</h1>
+          <p>erm</p>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,6 +12,8 @@ const config: Config = {
         "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
         "gradient-conic":
           "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
+        "shimmer-pattern":
+          "linear-gradient(90deg, #e0e0e0 25%, #f0f0f0 50%, #e0e0e0 75%)",
       },
       colors: {
         "main-red": "#ECE8EF",
@@ -24,9 +26,17 @@ const config: Config = {
           "0%": { opacity: "0" },
           "100%": { opacity: "1" },
         },
+        shimmer: {
+          "0%": { backgroundPosition: "200% 0" },
+          "100%": { backgroundPosition: "-200% 0" },
+        },
       },
       animation: {
         fadeIn: "fadeIn 0.4s ease-in forwards",
+        shimmer: "shimmer 1.5s infinite linear",
+      },
+      backgroundSize: {
+        "200%": "200% 100%",
       },
     },
   },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,6 +13,12 @@ const config: Config = {
         "gradient-conic":
           "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
       },
+      colors: {
+        "main-red": "#ECE8EF",
+        "main-pink": "#D34F73",
+        "main-black": "#040F16",
+        "main-lightblack": "#0A100D",
+      },
     },
   },
   plugins: [],

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,6 +19,15 @@ const config: Config = {
         "main-black": "#040F16",
         "main-lightblack": "#0A100D",
       },
+      keyframes: {
+        fadeIn: {
+          "0%": { opacity: "0" },
+          "100%": { opacity: "1" },
+        },
+      },
+      animation: {
+        fadeIn: "fadeIn 0.4s ease-in forwards",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Overview
- Created register and login page
- Created the @auth parallel route, which intercepts /register and /login and displays the corresponding modal (first image)
- On hard navigation / page refresh on those routes, it displays the same modal on a blank page (second image)
- Created loading skeleton for forms, and a Delay component to show off skeletons for a set delay, before rendering the real form

## Related Ticket
- https://github.com/JrodanDiaz/Swapify/issues/1

## Images
![image](https://github.com/JrodanDiaz/Swapify/assets/129818825/786cfd19-2018-416c-b3b2-b989c40c888c)

![image](https://github.com/JrodanDiaz/Swapify/assets/129818825/1fddb7d5-2026-40fe-a45b-a9a6610b825b)



